### PR TITLE
ball possession timers issue fixed 

### DIFF
--- a/LookScore/LookScoreCommon/Converter/ScoreBoardConverter.cs
+++ b/LookScore/LookScoreCommon/Converter/ScoreBoardConverter.cs
@@ -7,13 +7,15 @@ namespace LookScoreCommon.Converter
 {
     public class ScoreBoardConverter : IValueConverter
     {
+        private const string TIE = "0 : 0";
+
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null) return value;
 
             if (!(value is GameStatistics statistics))
             {
-                return "0 : 0";
+                return TIE;
             }
 
             return statistics.HomeClub.Goal + " : " + statistics.GuestClub.Goal;

--- a/LookScore/LookScoreManageStatisticsClient/App.config
+++ b/LookScore/LookScoreManageStatisticsClient/App.config
@@ -15,7 +15,7 @@
 				</identity>
 			</endpoint>
 			<endpoint address="http://localhost:9999/LookScoreServer.Service.WCFServices/GameService/"
-			 binding="basicHttpBinding" bindingConfiguration="" contract="LookScoreServer.Service.WCFServices.IGameService"
+			 binding="wsDualHttpBinding" bindingConfiguration="" contract="LookScoreServer.Service.WCFServices.IGameService"
 			 name="GameService" kind="" endpointConfiguration="">
 				<identity>
 					<dns value="localhost" />

--- a/LookScore/LookScoreManageStatisticsClient/Contract/GameCallback.cs
+++ b/LookScore/LookScoreManageStatisticsClient/Contract/GameCallback.cs
@@ -1,0 +1,34 @@
+﻿using LookScoreCommon.Model;
+using LookScoreServer.Service.WCFServices;
+using System;
+using System.ServiceModel;
+
+namespace LookScoreManageStatisticsClient.Contract
+{
+    [CallbackBehavior(UseSynchronizationContext = false)]
+    public class GameCallback : IGameCallbackService
+    {
+        public event EventHandler<GameEventArgs> GameStarted;
+        public event EventHandler<GameEventArgs> GameStopped;
+
+        public void NotifyGameStarted(Game game)
+        {
+            OnGameStarted(game);
+        }
+
+        public void NotifyGameStop(Game game)
+        {
+            OnGameStopped(game);
+        }
+
+        protected virtual void OnGameStarted(Game game)
+        {
+            GameStarted?.Invoke(this, new GameEventArgs() { Game = game });
+        }
+
+        protected virtual void OnGameStopped(Game game)
+        {
+            GameStopped?.Invoke(this, new GameEventArgs() { Game = game });
+        }
+    }
+}

--- a/LookScore/LookScoreManageStatisticsClient/Contract/GameEventArgs.cs
+++ b/LookScore/LookScoreManageStatisticsClient/Contract/GameEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using LookScoreCommon.Model;
+using System;
+
+namespace LookScoreManageStatisticsClient.Contract
+{
+    public class GameEventArgs : EventArgs
+    {
+        public Game Game { get; set; }
+    }
+}

--- a/LookScore/LookScoreManageStatisticsClient/Contract/GameStatisticsCallback.cs
+++ b/LookScore/LookScoreManageStatisticsClient/Contract/GameStatisticsCallback.cs
@@ -1,16 +1,24 @@
 ﻿using LookScoreCommon.Model;
 using LookScoreServer.Service.WCFServices;
+using System;
 using System.ServiceModel;
 using System.Windows;
 
 namespace LookScoreManageStatisticsClient.Contract
 {
-    //[CallbackBehavior(UseSynchronizationContext = false)]
+    [CallbackBehavior(UseSynchronizationContext = false)]
     public class GameStatisticsCallback : IStatisticCallbackService
     {
+        public event EventHandler<StatisticEventArgs> StatisticsChanged;
+
         public void NotifyGoalScored(GameStatistics gameStatistics)
         {
+            OnStatisticsChanged(gameStatistics);
+        }
 
+        protected virtual void OnStatisticsChanged(GameStatistics statistics)
+        {
+            StatisticsChanged?.Invoke(this, new StatisticEventArgs() { GameStatistics = statistics });
         }
     }
 }

--- a/LookScore/LookScoreManageStatisticsClient/Contract/StatisticEventArgs.cs
+++ b/LookScore/LookScoreManageStatisticsClient/Contract/StatisticEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using LookScoreCommon.Model;
+using System;
+
+namespace LookScoreManageStatisticsClient.Contract
+{
+    public class StatisticEventArgs : EventArgs
+    {
+        public GameStatistics GameStatistics { get; set; }
+    }
+}

--- a/LookScore/LookScoreManageStatisticsClient/LookScoreManageStatisticsClient.csproj
+++ b/LookScore/LookScoreManageStatisticsClient/LookScoreManageStatisticsClient.csproj
@@ -103,7 +103,10 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Contract\GameCallback.cs" />
+    <Compile Include="Contract\GameEventArgs.cs" />
     <Compile Include="Contract\GameStatisticsCallback.cs" />
+    <Compile Include="Contract\StatisticEventArgs.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />
     <Compile Include="View\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/LookScore/LookScoreManageStatisticsClient/View/MainWindow.xaml
+++ b/LookScore/LookScoreManageStatisticsClient/View/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:viewModel="clr-namespace:LookScoreManageStatisticsClient.ViewModel"
         xmlns:enum="clr-namespace:LookScoreCommon.Enums;assembly=LookScoreCommon"
         xmlns:fa="clr-namespace:FontAwesome.WPF;assembly=FontAwesome.WPF"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity" xmlns:commonView="clr-namespace:LookScoreCommon.View;assembly=LookScoreCommon"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="1200">
 
@@ -54,66 +54,13 @@
 
 
         <StackPanel Grid.Row="1" Orientation="Vertical">
-            <StackPanel 
-                Orientation="Horizontal"
-                VerticalAlignment="Top"
-                HorizontalAlignment="Center"
-                Margin="5, 20, 5, 0"
-                Height="40"
-                Background="#14C38E">
-                <!--Score Board-->
-                <Border Width="Auto">
-                    <TextBlock Text="{Binding SelectedGame.HomeClub.Name, UpdateSourceTrigger=PropertyChanged}"
-                               FontSize="18"
-                               VerticalAlignment="Center"
-                               Margin="10, 5, 10, 5"
-                               Foreground="White"/>
-                </Border>
-
-                <Border Width="Auto"
-                        Padding="2"
-                        BorderBrush="LightGray"
-                        BorderThickness="3, 0, 3, 0" >
-                    <TextBlock Text="{Binding CurrentGameStatistics, Converter={StaticResource ScoreBoardConverter}}"
-                               FontSize="22"
-                               VerticalAlignment="Center"
-                               HorizontalAlignment="Center"
-                               Margin="5, 0, 5, 0"
-                               Foreground="White"/>
-                </Border>
-
-                <Border Width="Auto">
-                    <TextBlock Text="{Binding SelectedGame.GuestClub.Name, UpdateSourceTrigger=PropertyChanged}"
-                               FontSize="18"
-                               VerticalAlignment="Center"
-                               Margin="10, 5, 10, 5"
-                               Foreground="White"/>
-                </Border>
-
-                <Border Background="#F2F2F2"
-                        Width="Auto">
-                    <StackPanel VerticalAlignment="Center"
-                                Orientation="Horizontal">
-                        <TextBlock Text="45 : 00"
-                                    FontSize="18"
-                               VerticalAlignment="Center"
-                               HorizontalAlignment="Left"
-                               Margin="5, 0, 10, 0"
-                               Foreground="Black"
-                                 />
-
-                        <TextBlock Text="2:12"
-                                    FontSize="18"
-                               VerticalAlignment="Center"
-                               HorizontalAlignment="Right"
-                               Margin="5, 0, 10, 0"
-                               Foreground="Black"
-                                   FontStyle="Italic" />
-
-                    </StackPanel>
-                </Border>
-
-            </StackPanel>
+            <commonView:ScoreBoardView
+                    Game="{Binding SelectedGame, UpdateSourceTrigger=PropertyChanged}"
+                    GameStatistics="{Binding CurrentGameStatistics, 
+                                UpdateSourceTrigger=PropertyChanged}"
+                    IsGameStart="{Binding IsGameStart, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
+                    IsGameStop="{Binding IsGameStop, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}"
+                 />
 
             <Grid  
                         Margin="10"

--- a/LookScore/LookScoreTimeRefereeClient/ViewModel/MainViewModel.cs
+++ b/LookScore/LookScoreTimeRefereeClient/ViewModel/MainViewModel.cs
@@ -171,6 +171,7 @@ namespace LookScoreTimeRefereeClient.ViewModel
         private void SendPossessionResult()
         {
             _statisticService.ChangeStatistic(CurrentGameStatistics);
+            Monitor.Enter(CurrentGameStatistics);
         }
 
         #endregion


### PR DESCRIPTION
**Problem**
this issue occured when client click send result button, in that method client is using lock object, that's why lock acquired for that locked object, then thread started to increase timer so fast

**Solution**
Adding Monitor.Start(<lock object>), to make lock object locking again after use it
